### PR TITLE
Restore home html theme from github

### DIFF
--- a/Home.html
+++ b/Home.html
@@ -796,7 +796,6 @@
             margin-top: 0.5rem;
             font-weight: 600;
         }
-
         .daily-inspiration-section .inspiration-actions {
             display: flex;
             gap: 1rem;
@@ -2218,7 +2217,7 @@
             <div class="user-profile-header" style="display:flex;align-items:center;gap:10px;">
                 <!-- Theme Switcher Button -->
                 <button id="themeSwitcherBtn" class="theme-switcher-btn" aria-label="Switch Theme">
-                    <i class="fas fa-palette"></i>
+                    <i class="fas fa-key"></i>
                 </button>
                 <!-- Admin Icon Link (visible only to admin) -->
                 <a href="/Admin.html" id="adminIconLink" aria-label="Admin Dashboard" style="display: none;">
@@ -2536,7 +2535,6 @@
             </div>
         </div>
     </div>
-
     <script type="module">
         console.log("JCHAT_DEBUG: Home.html script started.");
 
@@ -2682,18 +2680,7 @@
             if (themeSwitcherBtn) {
                 const icon = themeSwitcherBtn.querySelector('i');
                 if (icon) {
-                    switch (theme) {
-                        case 'theme-light-mode':
-                            icon.className = 'fas fa-sun';
-                            break;
-                        case 'theme-sunset-mode':
-                            icon.className = 'fas fa-moon';
-                            break;
-                        case 'theme-dark-mode':
-                        default:
-                            icon.className = 'fas fa-palette';
-                            break;
-                    }
+                    icon.className = 'fas fa-key';
                 }
             }
             
@@ -3322,13 +3309,6 @@
 
             return notification;
         }
-
-
-
-
-
-
-
         /**
          * Plays a notification sound based on type.
          * @param {string} type - 'success', 'error', 'info', 'warning', 'friend_request', 'message', 'level_up'.
@@ -4119,7 +4099,6 @@
                 showMessageBox(`Failed to save inspiration type: ${error.message}`, 'error');
             }
         }
-
         // Event listener for post media upload input.
         if (postMediaUpload) {
             postMediaUpload.addEventListener('change', (event) => {
@@ -4886,8 +4865,6 @@
             `;
             return commentElement;
         }
-
-
         /**
          * Fetches and displays posts in real-time using Firestore onSnapshot.
          * Manages post and comment listeners, and updates the UI dynamically.
@@ -5585,7 +5562,6 @@
                 console.error("JCHAT_ERROR: Error listening for incoming calls:", error);
             });
         }
-
         /**
          * Handles accepting an incoming call.
          * Initializes WebRTC peer connection, gets local media, sets remote description,
@@ -6370,7 +6346,6 @@
                 } catch(e) { console.error(e); showMessageBox('Spin failed.', 'error'); }
             });
         }
-
         // Stories
         const addStoryButton = document.getElementById('addStoryButton');
         const storyUploadInput = document.getElementById('storyUploadInput');


### PR DESCRIPTION
Changes the theme switcher icon to a static key icon while retaining theme-switching functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9da0ace-0f7a-43e6-b027-632ea0509fda">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f9da0ace-0f7a-43e6-b027-632ea0509fda">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

