### PR TITLE
Say hello

### DIFF
--- a/Chat.html
+++ b/Chat.html
@@ -2155,7 +2155,9 @@
             margin: 20px 0;
         }
 
-        .action-btn.loading 
+        .action-btn.loading {
+            /* Loading state styles */
+        }
 
         .action-btn.loading .button-text {
             display: none;


### PR DESCRIPTION
Adds missing curly braces to `.action-btn.loading` CSS rule to fix `SyntaxError: Unexpected token ')'`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ef7d788-efa6-40dc-9ce3-54e358908973">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ef7d788-efa6-40dc-9ce3-54e358908973">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

